### PR TITLE
Upgrade dependent prometheus plugin

### DIFF
--- a/.github/workflows/run_spec.yml
+++ b/.github/workflows/run_spec.yml
@@ -5,15 +5,21 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+        ruby_version: [2.5, 2.6, 2.7, 3.0]
+        experimental: [false]
+        include:
+          - ruby_version: head
+            os: ubuntu-latest
+            experimental: true
     env:
       LANG: en_US.UTF-8
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{  matrix.ruby_version }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
     - name: Install dependencies

--- a/fluent-plugin-prometheus_pushgateway.gemspec
+++ b/fluent-plugin-prometheus_pushgateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license = "Apache-2.0"
 
-  spec.add_dependency "fluent-plugin-prometheus", ">= 1.7.0", "< 2.0.0"
+  spec.add_dependency "fluent-plugin-prometheus", ">= 2.0.0", "< 2.1.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
It should be upgraded dependent prometheus plugin due to Ruby 3.0.
Ruby 3.0 removes URI.escape which is warned deprecated method for a long
time.

Closes #4.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>