### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/run_spec.yml
+++ b/.github/workflows/run_spec.yml
@@ -12,7 +12,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        ruby_version: [ '3.1', '3.0', '2.7', '2.6' ]
+        ruby_version: [ '3.2', '3.1', '3.0', '2.7' ]
         experimental: [false]
         include:
           - ruby_version: head

--- a/fluent-plugin-prometheus_pushgateway.gemspec
+++ b/fluent-plugin-prometheus_pushgateway.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.license = "Apache-2.0"
 
   spec.add_dependency "fluent-plugin-prometheus", ">= 2.0.0", "< 2.1.0"
+  # Need to fix to support 3.0 or later
+  spec.add_dependency "prometheus-client", "~> 2.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
* Add Ruby 3.2 and drop 2.6
* Add dependabot to watch updates of GitHub Actions
* Stay on prometheus-client 2.1.0
  * We need to fix the plugin to support 3.0 or later