### PR TITLE
Try to support prometheus-client 3.0 or later

### DIFF
--- a/fluent-plugin-prometheus_pushgateway.gemspec
+++ b/fluent-plugin-prometheus_pushgateway.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
   spec.license = "Apache-2.0"
 
   spec.add_dependency "fluent-plugin-prometheus", ">= 2.0.0", "< 2.2.0"
-  # Need to fix to support 3.0 or later
-  spec.add_dependency "prometheus-client", "~> 2.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_prometheus_pushgateway.rb
+++ b/lib/fluent/plugin/out_prometheus_pushgateway.rb
@@ -15,6 +15,7 @@
 #
 
 require 'prometheus/client/push'
+require 'prometheus/client/version'
 require 'fluent/plugin/output'
 
 begin
@@ -69,7 +70,12 @@ module Fluent
       def configure(conf)
         super
 
-        @push_client = ::Prometheus::Client::Push.new("#{@job_name}:#{fluentd_worker_id}", @instance, @gateway)
+        if Prometheus::Client::VERSION.split(".")[0].to_i > 3
+          grouping_key = @instance ? {instance: @instance} : {}
+          @push_client = ::Prometheus::Client::Push.new(job: "#{@job_name}:#{fluentd_worker_id}", grouping_key: grouping_key, gateway: @gateway)
+        else
+          @push_client = ::Prometheus::Client::Push.new("#{@job_name}:#{fluentd_worker_id}", @instance, @gateway)
+        end
 
         use_tls = gateway && (URI.parse(gateway).scheme == 'https')
 

--- a/lib/fluent/plugin/out_prometheus_pushgateway.rb
+++ b/lib/fluent/plugin/out_prometheus_pushgateway.rb
@@ -70,7 +70,7 @@ module Fluent
       def configure(conf)
         super
 
-        if Prometheus::Client::VERSION.split(".")[0].to_i > 3
+        if Prometheus::Client::VERSION.split(".")[0].to_i >= 3
           grouping_key = @instance ? {instance: @instance} : {}
           @push_client = ::Prometheus::Client::Push.new(job: "#{@job_name}:#{fluentd_worker_id}", grouping_key: grouping_key, gateway: @gateway)
         else


### PR DESCRIPTION
Since initialization parameters of `Prometheus::Client::Push` are changes since prometheus-client v3.0, we need to adapt to it.

https://github.com/prometheus/client_ruby/releases/tag/v3.0.0