### PR TITLE
Relax required fluent-plugin-prometheus

### DIFF
--- a/fluent-plugin-prometheus_pushgateway.gemspec
+++ b/fluent-plugin-prometheus_pushgateway.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.license = "Apache-2.0"
 
-  spec.add_dependency "fluent-plugin-prometheus", ">= 2.0.0", "< 2.1.0"
+  spec.add_dependency "fluent-plugin-prometheus", ">= 2.0.0", "< 2.2.0"
   # Need to fix to support 3.0 or later
   spec.add_dependency "prometheus-client", "~> 2.1"
 


### PR DESCRIPTION
bundle exec rspec has passed.

![prometheus-2 1 0](https://github.com/fluent/fluent-plugin-prometheus_pushgateway/assets/225841/d3a2f9ca-4aa1-4be3-ba8d-55f8515c4eef)
